### PR TITLE
Encaps speedup with vector instructions on AVX2 and AVX512.

### DIFF
--- a/include/internal/bike_defs.h
+++ b/include/internal/bike_defs.h
@@ -45,7 +45,8 @@
 #  error "Bad level, choose one of 1/3/5"
 #endif
 
-#define MAX_D_T 256
+// Round largest of D,T to a multiple of DWORDS_IN_ZMM
+#define MAX_D_T      (DWORDS_IN_ZMM * DIVIDE_AND_CEIL(T, DWORDS_IN_ZMM))
 #define NUM_OF_SEEDS 2
 
 // Round the size to the nearest byte.

--- a/include/internal/bike_defs.h
+++ b/include/internal/bike_defs.h
@@ -45,8 +45,6 @@
 #  error "Bad level, choose one of 1/3/5"
 #endif
 
-// Round largest of D,T to a multiple of DWORDS_IN_ZMM
-#define MAX_D_T      (DWORDS_IN_ZMM * DIVIDE_AND_CEIL(T, DWORDS_IN_ZMM))
 #define NUM_OF_SEEDS 2
 
 // Round the size to the nearest byte.

--- a/include/internal/bike_defs.h
+++ b/include/internal/bike_defs.h
@@ -45,6 +45,7 @@
 #  error "Bad level, choose one of 1/3/5"
 #endif
 
+#define MAX_D_T 256
 #define NUM_OF_SEEDS 2
 
 // Round the size to the nearest byte.

--- a/include/internal/defs.h
+++ b/include/internal/defs.h
@@ -30,7 +30,7 @@
 #endif
 
 // Divide by the divider and round up to next integer
-#define DIVIDE_AND_CEIL(x, divider) (((x) + (divider)) / (divider))
+#define DIVIDE_AND_CEIL(x, divider) (((x) + (divider) - 1) / (divider))
 
 // Bit manipulations
 // Linux Assemblies, except for Ubuntu, cannot understand what ULL mean.
@@ -49,6 +49,9 @@
 
 #define WORDS_IN_YMM (BYTES_IN_YMM / sizeof(uint16_t))
 #define WORDS_IN_ZMM (BYTES_IN_ZMM / sizeof(uint16_t))
+
+#define DWORDS_IN_YMM (BYTES_IN_YMM / sizeof(uint32_t))
+#define DWORDS_IN_ZMM (BYTES_IN_ZMM / sizeof(uint32_t))
 
 #define QWORDS_IN_XMM (BYTES_IN_XMM / sizeof(uint64_t))
 #define QWORDS_IN_YMM (BYTES_IN_YMM / sizeof(uint64_t))

--- a/include/internal/defs.h
+++ b/include/internal/defs.h
@@ -30,7 +30,7 @@
 #endif
 
 // Divide by the divider and round up to next integer
-#define DIVIDE_AND_CEIL(x, divider) (((x) + (divider) - 1) / (divider))
+#define DIVIDE_AND_CEIL(x, divider) (((x) + (divider)-1) / (divider))
 
 // Bit manipulations
 // Linux Assemblies, except for Ubuntu, cannot understand what ULL mean.

--- a/include/internal/defs.h
+++ b/include/internal/defs.h
@@ -104,6 +104,7 @@
 // NOLINT is used to avoid the sizeof(T)/sizeof(T) warning when REG_T is defined
 // to be uint64_t
 #define REG_QWORDS (sizeof(REG_T) / sizeof(uint64_t)) // NOLINT
+#define REG_DWORDS (sizeof(REG_T) / sizeof(uint32_t)) // NOLINT
 
 ////////////////////////////////////////////
 //             Debug

--- a/include/internal/x86_64_intrinsic.h
+++ b/include/internal/x86_64_intrinsic.h
@@ -69,6 +69,7 @@
 
 #  define CMPGT_I16(a, b) _mm256_cmpgt_epi16(a, b)
 #  define CMPEQ_I16(a, b) _mm256_cmpeq_epi16(a, b)
+#  define CMPEQ_I32(a, b) _mm256_cmpeq_epi32(a, b)
 #  define CMPEQ_I64(a, b) _mm256_cmpeq_epi64(a, b)
 
 #  define SHUF_I8(a, b)         _mm256_shuffle_epi8(a, b)
@@ -83,6 +84,7 @@
 #  define MSTORE(mem, mask, reg) _mm512_mask_store_epi64((mem), (mask), (reg))
 
 #  define SET1_I8(a)         _mm512_set1_epi8(a)
+#  define SET1_I32(a)        _mm512_set1_epi32(a)
 #  define SET1_I64(a)        _mm512_set1_epi64(a)
 #  define SET1MZ_I8(mask, a) _mm512_maskz_set1_epi8(mask, a)
 #  define SET1_I16(a)        _mm512_set1_epi16(a)
@@ -101,6 +103,8 @@
 
 #  define CMPM_U8(a, b, cmp_op)  _mm512_cmp_epu8_mask(a, b, cmp_op)
 #  define CMPM_U16(a, b, cmp_op) _mm512_cmp_epu16_mask(a, b, cmp_op)
+#  define CMPMEQ_I32(a, b)          _mm512_cmp_epi32_mask(a, b, _MM_CMPINT_EQ)
+#  define MCMPMEQ_I32(mask, a, b)   _mm512_mask_cmp_epi32_mask(mask, a, b, _MM_CMPINT_EQ)
 #  define CMPMEQ_I64(a, b)       _mm512_cmp_epi64_mask(a, b, _MM_CMPINT_EQ)
 
 #  define PERMX_I64(a, imm)        _mm512_permutex_epi64(a, imm)

--- a/include/internal/x86_64_intrinsic.h
+++ b/include/internal/x86_64_intrinsic.h
@@ -103,9 +103,10 @@
 
 #  define CMPM_U8(a, b, cmp_op)  _mm512_cmp_epu8_mask(a, b, cmp_op)
 #  define CMPM_U16(a, b, cmp_op) _mm512_cmp_epu16_mask(a, b, cmp_op)
-#  define CMPMEQ_I32(a, b)          _mm512_cmp_epi32_mask(a, b, _MM_CMPINT_EQ)
-#  define MCMPMEQ_I32(mask, a, b)   _mm512_mask_cmp_epi32_mask(mask, a, b, _MM_CMPINT_EQ)
-#  define CMPMEQ_I64(a, b)       _mm512_cmp_epi64_mask(a, b, _MM_CMPINT_EQ)
+#  define CMPMEQ_I32(a, b)       _mm512_cmp_epi32_mask(a, b, _MM_CMPINT_EQ)
+#  define MCMPMEQ_I32(mask, a, b) \
+    _mm512_mask_cmp_epi32_mask(mask, a, b, _MM_CMPINT_EQ)
+#  define CMPMEQ_I64(a, b) _mm512_cmp_epi64_mask(a, b, _MM_CMPINT_EQ)
 
 #  define PERMX_I64(a, imm)        _mm512_permutex_epi64(a, imm)
 #  define PERMX2VAR_I64(a, idx, b) _mm512_permutex2var_epi64(a, idx, b)

--- a/src/random/sampling.c
+++ b/src/random/sampling.c
@@ -95,72 +95,105 @@ ret_t sample_uniform_r_bits_with_fixed_prf_context(
   return SUCCESS;
 }
 
-#if defined (AVX2)
-
+// Wlist[ctr] is compared to w[i] for all i < ctr.
+// Returns 0 if wlist[ctr] is already contained in wlist.
+// Returns 1 otherwise.
 _INLINE_ int is_new(IN const idx_t *wlist, IN const size_t ctr)
 {
-    REG_T complist, current, comp;
-    uint32_t check;
-    current = SET1_I32(wlist[ctr]);
-    for(size_t i = 0; i < (ctr/DWORDS_IN_YMM); i++)
-    {
-        complist = LOAD(&wlist[i * DWORDS_IN_YMM]); 
-        comp = CMPEQ_I32(current, complist);
-        check = MOVEMASK(comp);
 
-        if(check != 0)
-            return 0;
+#if defined(AVX2)
+
+  // On AVX2 comparisons are done by using vector instructions, each vector
+  // containing DWORDS_IN_YMM=8 elements. Comparisons are done by comparing
+  // current={8 repetitions of wlist[ctr]} with complist={8 consecutive elements
+  // from wlist}. At the last step we only consider the comparisons up to ctr by
+  // masking the output of the comp instruction.
+  REG_T    complist, current, comp;
+  uint32_t check;
+  current =
+    SET1_I32(wlist[ctr]); // broadcast wlist[ctr] to 8 elements in the vector
+
+  for(size_t i = 0; i < (ctr / DWORDS_IN_YMM); i++) {
+    // Load 8 consecutive elements from wlist.
+    // Compare and save as "check", a uint32_t divided into 8 chunks of 4 bits.
+    // Each chunk is 0xF or 0x0 if the loaded element with correspoiding index is
+    // equal to wlist[ctr] or not.
+    complist = LOAD(&wlist[i * DWORDS_IN_YMM]);
+    comp     = CMPEQ_I32(current, complist);
+    check    = MOVEMASK(comp);
+
+    if(check != 0) {
+      return 0;
     }
-    complist = LOAD(&wlist[(ctr/DWORDS_IN_YMM) * DWORDS_IN_YMM]);
-    comp = CMPEQ_I32(current, complist);
-    check = MOVEMASK(comp);
+  }
 
-    if((check & MASK(sizeof(idx_t) * (ctr & MASK(LOG2_MSB(DWORDS_IN_YMM) - 1)))) != 0)
-        return 0;
+  // Load last vector of 8 elements is loaded. Some of these might be wllist[i]
+  // for i>=ctr. This is dealt with by masking the check and considering only the
+  // first (ctr % 8) comparisons.
+  complist = LOAD(&wlist[(ctr / DWORDS_IN_YMM) * DWORDS_IN_YMM]);
+  comp     = CMPEQ_I32(current, complist);
+  check    = MOVEMASK(comp);
+  check &=
+    MASK(sizeof(idx_t) * (ctr & MASK(LOG2_MSB(DWORDS_IN_YMM) -
+                                     1))); // sizeof(idx_t) = 4,  ctr%8 = ctr &
+                                           // MASK(LOG2_MSB(DWORDS_IN_YMM) - 1)
+  if(check != 0) {
+    return 0;
+  }
 
-    return 1;
-}
+  return 1;
 
 #elif defined(AVX512)
 
-_INLINE_ int is_new(IN const idx_t *wlist, IN const size_t ctr)
-{
-    REG_T complist, current;
-    uint32_t check;
+  // On AVX512 comparisons are done by using vector instructions, each vector
+  // containing DWORDS_IN_ZMM=16 elements. Comparisons are done by comparing
+  // current={16 repetitions of wlist[ctr]} with complist={16 consecutive elements
+  // from wlist}. At the last step we only consider the comparisons up to ctr by
+  // using a masked comp instruction.
+  REG_T    complist, current;
+  uint32_t check;
 
-    current = SET1_I32(wlist[ctr]);
+  current =
+    SET1_I32(wlist[ctr]); // broadcast wlist[ctr] to 16 elements in the vector
 
-    for(size_t i = 0; i < (ctr/DWORDS_IN_ZMM); i++)
-    {
-        complist = LOAD(&wlist[i * DWORDS_IN_ZMM]); 
-        check = CMPMEQ_I32(current, complist);
-        if(check != 0)
-            return 0;
+  for(size_t i = 0; i < (ctr / DWORDS_IN_ZMM); i++) {
+    // Load 16 consecutive elements from wlist.
+    // Comparison outputs 16 bits, each being 1 or 0 depending if the loaded
+    // element with corresponding index is equal to wlist[ctr] or not.
+    complist = LOAD(&wlist[i * DWORDS_IN_ZMM]);
+    check    = CMPMEQ_I32(current, complist);
+    if(check != 0) {
+      return 0;
     }
+  }
 
-    complist = LOAD(&wlist[(ctr/DWORDS_IN_ZMM) * DWORDS_IN_ZMM]); 
-    check = MCMPMEQ_I32(MASK(ctr & MASK(LOG2_MSB(DWORDS_IN_ZMM) - 1)), current, complist);
-    if(check != 0)
-        return 0;
+  // Last vector of 16 elements is loaded.
+  // Comparison is done with a mask in order to compare only with the first (ctr %
+  // 16) elements. The output is (ctr % 16) bits each being 1 or 0 depending if
+  // the loaded element with corresponding index is equal to wlist[ctr] or not.
+  complist = LOAD(&wlist[(ctr / DWORDS_IN_ZMM) * DWORDS_IN_ZMM]);
+  check =
+    MCMPMEQ_I32(MASK(ctr & MASK(LOG2_MSB(DWORDS_IN_ZMM) - 1)), current,
+                complist); // ctr%16 = ctr & MASK(LOG2_MSB(DWORDS_IN_ZMM) - 1)
+  if(check != 0) {
+    return 0;
+  }
 
-    return 1;
-}
+  return 1;
 
 #else
 
-_INLINE_ int is_new(IN const idx_t *wlist, IN const size_t ctr)
-{
-    for(size_t i = 0; i < ctr; i++) {
-        if(wlist[i] == wlist[ctr]) {
-            return 0;
-        }   
+  // Without vector operations we do a standard comparison.
+  for(size_t i = 0; i < ctr; i++) {
+    if(wlist[i] == wlist[ctr]) {
+      return 0;
     }
+  }
 
   return 1;
-}
 
 #endif
-
+}
 
 ret_t generate_indices_mod_z(OUT idx_t *     out,
                              IN const size_t num_indices,
@@ -199,7 +232,9 @@ ret_t generate_sparse_rep(OUT pad_r_t *r,
                           OUT idx_t *wlist,
                           IN OUT aes_ctr_prf_state_t *prf_state)
 {
-  idx_t wlist_temp[MAX_D_T] = {0};  // For speeding up index generation with AVX2 and AVX512 vector instructions. Vector instructions on arrays of length p lead to segmentation faults.
+  idx_t wlist_temp[MAX_D_T] = {
+    0}; // Elements are loaded into SIMD registers of size DWORDS_IN_YMM=8 or
+        // DWORDS_IN_ZMM=16 so the size iz rounded to the topmost DWORDS multiple.
 
   GUARD(generate_indices_mod_z(wlist_temp, D, R_BITS, prf_state));
 
@@ -215,7 +250,9 @@ ret_t generate_error_vector(OUT pad_e_t *e, IN const seed_t *seed)
 
   GUARD(init_aes_ctr_prf_state(&prf_state, MAX_AES_INVOKATION, seed));
 
-  idx_t wlist[MAX_D_T] = {0}; // For speeding up index generation with AVX2 and AVX512 vector instructions. Vector instructions on arrays of length p lead to segmentation faults.
+  idx_t wlist[MAX_D_T] = {
+    0}; // Elements are loaded into SIMD registers of size DWORDS_IN_YMM or
+        // DWORDS_IN_ZMM so the size iz rounded to the topmost DWORDS multiple.
   GUARD(generate_indices_mod_z(wlist, T, N_BITS, &prf_state));
 
   // (e0, e1) hold bits 0..R_BITS-1 and R_BITS..2*R_BITS-1 of the error, resp.


### PR DESCRIPTION
Keygen speedup with vector instructions on AVX2 and AVX512.. For this use new macros have been added to bike_defs.h, defs.h and x86_64_intrinsic.h. DIVIDE_AND_CEIL has been changed due to being erroneous on inputs which are multiples of the divisor.

*Issue #, if available:*
- DIVIDE_AND_CEIL(x, divisor) = ((x) + (divisor))/(divisor)  is erroneous when x is a multiple of the divisor.

- generate_indices_mod_z does not use AVX2/AVX512 vector instructions.

*Description of changes:*
- DIVIDE_AND_CEIL(x, divisor) changed to ((x) + (divisor) - 1)/(divisor)
Now correct if x is a multiple of the divisor.

- is_new(subfunction of generate_indices_mod_z) sped up by using vector instructions.
New macros added to bike_defs.h, defs.h and x86_64_intrinsic.h



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
