### PR TITLE
Eliminate secret-index array accesses and unnecessary static assert

### DIFF
--- a/include/internal/utilities.h
+++ b/include/internal/utilities.h
@@ -186,6 +186,11 @@ _INLINE_ uint32_t secure_l32_mask(IN const uint32_t v1, IN const uint32_t v2)
 #endif
 }
 
+// Return (-1) if v1 == v2, 0 otherwise
+_INLINE_ uint64_t secure_cmpeq64_mask(IN const uint64_t v1, IN const uint64_t v2) {
+    return -(1 - ((uint64_t)((v1-v2) | (v2-v1)) >> 63));
+}
+
 // bike_memcpy avoids the undefined behaviour of memcpy when byte_len=0
 _INLINE_ void *bike_memcpy(void *dst, const void *src, size_t byte_len)
 {

--- a/src/decode/decode_portable.c
+++ b/src/decode/decode_portable.c
@@ -37,7 +37,6 @@ rotr_big(OUT syndrome_t *out, IN const syndrome_t *in, IN size_t qw_num)
 _INLINE_ void
 rotr_small(OUT syndrome_t *out, IN const syndrome_t *in, IN const size_t bits)
 {
-  bike_static_assert(bits < 64, rotr_small_err);
   bike_static_assert(sizeof(*out) > (8 * R_QWORDS), rotr_small_qw_err);
 
   // Convert |bits| to 0/1 by using !!bits; then create a mask of 0 or


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/open-quantum-safe/liboqs/issues/1624

*Description of changes:*

This PR addresses two issues which were caught by liboqs automated constant-time testing. One of these involved a number of secret-dependent array accesses in `gf2x_mul_base_portable`. This can be fixed by putting the array accesses inside short loops and using a mask. The second involved an unnecessary static_assert statement; the fix was to remove it.

See also the analogous liboqs PR: https://github.com/open-quantum-safe/liboqs/pull/1632

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
